### PR TITLE
Add Node.js version 24.x to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@
         attestations: write
       strategy:
         matrix:
-          node-version: [20.x, 22.x]
+          node-version: [20.x, 22.x, 24.x]
       steps:
         - uses: actions/checkout@v5
         - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Testing improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R25): Added Node.js version `24.x` to the CI matrix to run tests on the latest Node.js release.