### PR TITLE
chore: bump version to 4.0.1 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions-rate-limit-reporter",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actions-rate-limit-reporter",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-rate-limit-reporter",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "GitHub Action used to report on current rate-limit data as part of an Actions workflow",
   "exports": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request makes a minor update to the package version in `package.json`, incrementing it from 4.0.0 to 4.0.1.