### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@
         matrix:
           node-version: [20.x, 22.x, 24.x]
       steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         - name: Use Node.js ${{ matrix.node-version }}
-          uses: actions/setup-node@v6
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
           with:
             node-version: ${{ matrix.node-version }}
         - name: Install Dependencies
@@ -43,6 +43,6 @@
             fi
           id: diff
         - name: Generate artifact attestation
-          uses: actions/attest-build-provenance@v4
+          uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
           with:
             subject-path: './dist'

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -38,7 +38,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install ESLint Dependencies
         run: |
@@ -54,7 +54,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v4.36.0
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/reporter-action-test.yml
+++ b/.github/workflows/reporter-action-test.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./
         id: reporter-test-step
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6 # v3.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Pin all GitHub Actions references from mutable tags to immutable full commit SHAs for improved supply chain security. Tags are preserved as inline comments for readability.